### PR TITLE
geocoding shops by the full_address method in the address table

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -6,7 +6,7 @@ class ShopsController < ApplicationController
       @shops = Shop.where(sql_query, query: "%#{params[:query]}%")
       @products = Product.where(sql_query, query: "%#{params[:query]}%")
     else
-      @shops = Shop.all
+      @shops = Shop.near('Brussels', 60)
     #   # @addresse = Address.near([current_user.address.latidude, 4.4433408], 2)
     #   @addresse = Address.near([params[:lat], params[:lng]], 20)
     #   if @addresse.empty?
@@ -15,11 +15,10 @@ class ShopsController < ApplicationController
     #   raise
     #   @shops = @shops.select { |shop| @addresse.include?(shop.address) }
     end
-    @addresses = Address.all
     @markers = @shops.map do |shop|
       {
-        lat: shop.address.latitude,
-        lng: shop.address.longitude,
+        lat: shop.latitude,
+        lng: shop.longitude,
         infoWindow: render_to_string(partial: "info_window", locals: { shop: shop })
       }
     end
@@ -69,6 +68,6 @@ class ShopsController < ApplicationController
   private
 
   def shop_params
-    params.require(:shop).permit(:name, :description, :vat_number, :address, :logo, pictures: [])
+    params.require(:shop).permit(:name, :description, :vat_number, :address, :logo, :longitude, :latitude, pictures: [])
   end
 end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -8,12 +8,17 @@ class Shop < ApplicationRecord
   has_many_attached :pictures
 
   has_many :products
-
+  geocoded_by :shop_address
+  after_validation :geocode
 
   validates :name, presence: true, length: { minimum: 2 }, uniqueness: true
   validates :description, presence: true, length: { minimum: 20 }
   validates :vat_number, format: { with: /BE\d{10}/ }
   # validates :vat_validation
+
+  def shop_address
+    self.address.full_address
+  end
 
   private
 

--- a/db/migrate/20201121093905_add_columns_to_shop.rb
+++ b/db/migrate/20201121093905_add_columns_to_shop.rb
@@ -1,0 +1,6 @@
+class AddColumnsToShop < ActiveRecord::Migration[6.0]
+  def change
+    add_column :shops, :longitude, :float
+    add_column :shops, :latitude, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_19_173625) do
+ActiveRecord::Schema.define(version: 2020_11_21_093905) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -133,6 +133,8 @@ ActiveRecord::Schema.define(version: 2020_11_19_173625) do
     t.string "vat_number"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.float "longitude"
+    t.float "latitude"
     t.index ["address_id"], name: "index_shops_on_address_id"
     t.index ["user_id"], name: "index_shops_on_user_id"
   end


### PR DESCRIPTION
Hello guys !

I managed to come to an easy solution to be able to fetch all the near shop without going through the process of "how the fuck can we have all near address, and retrieve the shops belonging to that address ?"

I just added latitude and longitude to the shop, and geocoded the shop by the full_address method of its address, therefore the geocode in the address might be useless now.

At least I think this will be much easier, without having to rewrite our tables or what.

Take some time to have a look, and tell me what you think about it.