### PR TITLE
improved footer to bottom and shop index page improved

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -1,0 +1,7 @@
+.home-banner {
+  padding: 10rem 0;
+  h1 {
+    font-weight: bold;
+    text-shadow: 1px 1px 2px black;
+  }
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -10,3 +10,4 @@
 @import "order_group";
 @import "form";
 @import "button";
+@import "banner";

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -1,6 +1,8 @@
 // Specific CSS for your home-page
-.container {
-  min-height: 85vmin;
+body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
 .round {

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,3 +1,4 @@
+<%= link_to  "Back", :back %>
 <h2><%= @category.name.capitalize %> items</h2>
 
 <%= render 'products/products', products: @products %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,14 @@
     <%= render 'shared/navbar' %>
     <%= render 'shared/flashes' %>
 
-    <div class="container my-4">
+    <% if request.path == '/shops' %>
+      <div class="home-banner w-100" style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url(<%= cl_image_path("banner1") %>);background-size: cover;background-position: center;">
+        <div class="container">
+          <h1 class="text-white">Support your local community</h1>
+        </div>
+      </div>      
+    <% end %>
+    <div class="container my-4 flex-grow-1">
       <%= yield %>
     </div>
     <%= render 'shared/footer' %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,4 +1,4 @@
-<div class="mt-n4 mx-auto" style="width:90%;" > 
+<div class="mt-n4 mx-auto" style="width:95%;" > 
   <%= image_tag 'home.svg', class:"w-100" %>
 </div>
 
@@ -10,8 +10,7 @@
 </div>
 
 <div class="w-75 mx-auto my-5">
-  <h4>
-    <span class="text-warning font-weight-bold">Shop locally</span> is the intersection where retailers and shoppers meet,
-    bringing the convenience of ecommerce to the local shopping experience.<br/>We help you find your favorite products at stores near you.
-  </h4>
+  <h2>
+    <span class="text-warning font-weight-bold">Shop locally</span> is the intersection where retailers and shoppers meet, bringing the convenience of e-commerce to the local shopping experience.<br/>We help you find your favorite products at stores near you.
+  </h2>
 </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,5 +1,5 @@
 <div class="navbar navbar-expand-sm navbar-light navbar-lewagon">
-  <%= link_to "/", class: "navbar-brand" do %>
+  <%= link_to "/shops", class: "navbar-brand" do %>
     <%= image_tag 'logo-shoplocally.png', class: "logo" %>
   <% end %>
 

--- a/app/views/shops/index.html.erb
+++ b/app/views/shops/index.html.erb
@@ -1,7 +1,31 @@
+<div class="row">
+  <div class="col-12 col-lg-6">
+    <h2>Top selling categories</h2>
+    <div class="row">
+      <% Category.all.each do |category| %>
+        <div class="col-6 col-lg-6 mb-4">
+          <%= link_to "categories/#{category.id}" do %>
+            <%= render  "categories/card", category: category %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+  <div class="col-12 col-lg-6">
+    <% unless @shops.empty? %>
+      <h2>Explore the shops around you</h2>
+        <div id="map"
+            style="width: 100%; height: 600px;"
+            data-markers="<%= @markers.to_json %>"
+            data-mapbox-api-key="<%= ENV['MAPBOX_API_KEY'] %>"></div>
+    <% end %>
+  </div>
+</div>
+
 <% if @products.nil? %>
   <h2>All shops near you <%= link_to icon('fas', 'plus'), new_shop_path, class: "text-warning" if current_user %></h2>
 <% else %>
-  <h2>Results for '<%= params[:query] %>'</h2>
+  <h2>Products result for '<%= params[:query] %>'</h2>
   <div class="row">
   <% @products&.each do |product| %>
       <div class="col-12 col-md-6 col-xl-4 mb-3">
@@ -9,6 +33,10 @@
       </div>
   <% end %>
   </div>
+  <h2>Shops result for '<%= params[:query] %>'</h2>
+  <% if @shops.empty? %>
+    <p>No results for '<%= params[:query] %>'</p>
+  <% end %>
 <% end %>
 <div class="row">
   <% @shops.each do |shop| %>
@@ -30,22 +58,3 @@
     </div>
   <% end %>
 </div>
-
-<h2>Browse categories</h2>
-
-<div class="row">
-  <% Category.all.each do |category| %>
-    <div class="col-12 col-md-4 mb-4">
-      <%= link_to "categories/#{category.id}" do %>
-        <%= render  "categories/card", category: category %>
-      <% end %>
-    </div>
-  <% end %>
-</div>
-<% unless @shops.empty? %>
-<h2>Explore the shops around you</h2>
-  <div id="map"
-      style="width: 100%; height: 600px;"
-      data-markers="<%= @markers.to_json %>"
-      data-mapbox-api-key="<%= ENV['MAPBOX_API_KEY'] %>"></div>
-<% end %>


### PR DESCRIPTION
The "home" page looks like figma now, we could try several pictures and see which one we prefer
![Screenshot from 2020-11-24 11-41-03](https://user-images.githubusercontent.com/13393121/100083731-1c2b7600-2e4a-11eb-9991-94795c4fbe7d.png)

I improved the footer sticking to the bottom by converting the whole body to a flex box with min-height of 100vh with flex-direction column and the content of the page has a flex grow 1
![Screenshot from 2020-11-24 11-41-16](https://user-images.githubusercontent.com/13393121/100083767-28173800-2e4a-11eb-8240-a4374ea5b829.png)
